### PR TITLE
Fixed translation for EPS and Giropay

### DIFF
--- a/catalog/language/nl-nl/payment/mollie.php
+++ b/catalog/language/nl-nl/payment/mollie.php
@@ -80,8 +80,8 @@ $_['method_paypal']       = 'PayPal';
 $_['method_paysafecard']  = 'paysafecard';
 $_['method_giftcard']     = 'Giftcard';
 $_['method_inghomepay']   = 'ING Home\'Pay';
-$_['method_eps']          = 'Giropay';
-$_['method_giropay']      = 'EPS';
+$_['method_eps']          = 'EPS';
+$_['method_giropay']      = 'Giropay';
 $_['method_klarnapaylater'] = 'Klarna Pay Later';
 $_['method_klarnasliceit']  = 'Klarna Slice It';
 


### PR DESCRIPTION
Labels at checkout were displaying the wrong text in Dutch. This fixes it.