### PR TITLE
NO-ISSUE: Fixed wrong shipping cost (tax missing).

### DIFF
--- a/catalog/controller/payment/mollie/base.php
+++ b/catalog/controller/payment/mollie/base.php
@@ -277,7 +277,7 @@ class ControllerPaymentMollieBase extends Controller
                 $tax_rates = $this->tax->getRates($cost, $taxClass);
                 $rates = $this->getTaxRate($tax_rates);
                 $vatRate = isset($rates[0]) ? $rates[0] : 0;
-                $costWithTax = $this->tax->calculate($cost, $taxClass, $this->config->get('config_tax'));
+                $costWithTax = $this->tax->calculate($cost, $taxClass, $vatRate);
                 $shippingVATAmount = $costWithTax * ( $vatRate / (100 +  $vatRate));
                 $lineForShipping[] = array(
                     'type'          =>  'shipping_fee',


### PR DESCRIPTION
When a company works with the setting 'show tax prices' disabled, Mollie is unable to process an order containing shipping fee.
This issue is caused due to a difference between the total and expected amount.

Instead of using the 'config_tax' variable for shipping fee I chose to use the $vatRate containing the percentage of the shipping method tax class.

**Steps to reproduce:**
- Disable 'config_tax' in administration settings of the desired company.
- Create a shipping method in X-Shipping which is set to use a Tax Class.
- Check out using the shipping method created above and Mollie will warn about the expected amount being different than the total OpenCart provides.