### PR TITLE
Bugfix breadcrumb bulding (session data token)

### DIFF
--- a/catalog/controller/payment/mollie/base.php
+++ b/catalog/controller/payment/mollie/base.php
@@ -1284,9 +1284,9 @@ class ControllerPaymentMollieBase extends Controller
         $data['breadcrumbs'] = array();
 
         $data['breadcrumbs'][] = array(
-            "href" => Util::url()->link("common/home", (isset($this->session->data['token'])) ? "token=" . $this->session->data['token'] : ""),
-            "text" => $this->language->get("text_home"),
-            "separator" => false,
+            'href'		=> Util::url()->link('common/home', ( defined('DIR_CATALOG') && isset($this->session->data['token'])) ? 'token=' . $this->session->data['token'] : ''),
+            'text'		=> $this->language->get('text_home'),
+            'separator'	=> false,
         );
     }
 


### PR DESCRIPTION
If breadcrumb is build from catalog side (store), the session data "token" may have been defined (because the store is opened from admin side.
But the token should not be added to the URL for standard operations, otherwise if the customer click on the breadcrumb (whch was broken before my previous pull request), the token is added to the URL.