### PR TITLE
bugfix cancelled status on payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # Changelog #
 
+#### Changes in release 11.0.1
+  + Fixed payment failed status
+  + Fixed permission error in admin after fresh install of the module
+  + Bug Fixes
+
 #### Changes in release 11.0.0
   + Added Klarna Pay Now payment method
   + Added Voucher payment method

--- a/admin/controller/payment/mollie/base.php
+++ b/admin/controller/payment/mollie/base.php
@@ -760,9 +760,7 @@ class ControllerPaymentMollieBase extends Controller {
 
 		foreach ($this->mollieHelper->MODULE_NAMES as $module_name) {
 			$extensions = $this->{$model}->getInstalled("payment");
-			if (in_array("mollie_" . $module_name, $extensions)) {
-				continue;
-			}
+			
 			// Install extension.
 			$this->{$model}->install("payment", "mollie_" . $module_name);
 
@@ -988,6 +986,9 @@ class ControllerPaymentMollieBase extends Controller {
             }
 
             if ($redirect) {
+				// Unset payment methods session in frontend
+				unset($this->session->data['mollie_allowed_methods']);
+
             	$this->session->data['success'] = $this->language->get('text_success');
             	if (version_compare(VERSION, '3', '>=')) {
 					$this->response->redirect($this->url->link('marketplace/extension', 'type=payment&' . $this->token, 'SSL'));

--- a/system/library/mollie/helper.php
+++ b/system/library/mollie/helper.php
@@ -4,7 +4,7 @@ use Mollie\Api\MollieApiClient;
 
 class MollieHelper {
 
-	const PLUGIN_VERSION = "11.0.0";
+	const PLUGIN_VERSION = "11.0.1";
 
 	const OUTH_URL = 'https://api.mollie.com/oauth2';
 


### PR DESCRIPTION
Bugfix with regards to payments being cancelled on success when using payment API