### PR TITLE
Fix formatting of negative roundoff

### DIFF
--- a/Opencart 1.5 - 3.x/catalog/controller/payment/mollie/base.php
+++ b/Opencart 1.5 - 3.x/catalog/controller/payment/mollie/base.php
@@ -787,8 +787,8 @@ class ControllerPaymentMollieBase extends Controller
                     'type'          =>  'discount',
                     'description'   =>  $this->formatText($this->language->get("roundoff_description")),
                     'quantity'      =>  1,
-                    'unitPrice'     =>  ["currency" => $currency, "value" => (string)-$amountDiff],
-                    'totalAmount'   =>  ["currency" => $currency, "value" => (string)-$amountDiff],
+                    'unitPrice'     =>  ["currency" => $currency, "value" => "-$amountDiff"],
+                    'totalAmount'   =>  ["currency" => $currency, "value" => "-$amountDiff"],
                     'vatRate'       =>  "0.00",
                     'vatAmount'     =>  ["currency" => $currency, "value" => (string)$this->numberFormat(0.00)]
                 );


### PR DESCRIPTION
In the current implementation, if a negative roundoff ends in '0' or '00', it gets rounded to 1dp or 0dp respectively. This results in the following error from the Mollie gateway: `(422: Unprocessable Entity): Line item 6 is invalid. The 'unitPrice.value' field has an invalid value.`

For example, if the roundoff difference is -10.30, it gets added to the request payload data as "-10.3", causing the above error.

This pull request fixes the formatting of negative roundoff differences such that they retain their 2 decimal places.